### PR TITLE
Split computer language installs out to their own role

### DIFF
--- a/roles/install_languages/tasks/main.yaml
+++ b/roles/install_languages/tasks/main.yaml
@@ -1,0 +1,9 @@
+---
+- name: Install Programming Languages (Homebrew)
+  homebrew:
+    name: "{{ item }}"
+    state: present
+  when: ansible_os_family == "Darwin"
+  with_items:
+    - 'rvm'
+    - 'go'

--- a/roles/install_utilities/tasks/main.yaml
+++ b/roles/install_utilities/tasks/main.yaml
@@ -19,7 +19,6 @@
     name: "{{ item }}"
     state: present
   with_items:
-    - 'rvm'
     - 'git'
     - 'fzf'
     - 'jq'

--- a/setup.yaml
+++ b/setup.yaml
@@ -3,3 +3,4 @@
   roles:
     - install_browsers
     - install_utilities
+    - install_languages


### PR DESCRIPTION
This list could get long, so I want to split it out.