### PR TITLE
Change the textmate bundles to use https over git ssh

### DIFF
--- a/roles/install_textmate_bundles/defaults/main.yaml
+++ b/roles/install_textmate_bundles/defaults/main.yaml
@@ -1,68 +1,68 @@
 bundles:
-  "Apache": git@github.com:textmate/apache.tmbundle
-  "AppleScript": git@github.com:textmate/applescript.tmbundle.git
-  "Bundle Development": git@github.com:textmate/bundle-development.tmbundle
-  "Bundle Support": git@github.com:textmate/bundle-support.tmbundle
-  "C": git@github.com:textmate/c.tmbundle
-  "CSS": git@github.com:textmate/css.tmbundle
-  "CoffeeScript": git@github.com:textmate/coffee-script.tmbundle
-  "Cron": git@github.com:textmate/cron.tmbundle.git
-  "Diff": git@github.com:textmate/diff.tmbundle
-  "Docker": git@github.com:asbjornenge/Docker.tmbundle.git
-  "Dylan": git@github.com:textmate/dylan.tmbundle
-  "Gist": git@github.com:infininight/Gist.tmbundle.git
-  "Git": git@github.com:textmate/git.tmbundle
-  "Go": git@github.com:syscrusher/golang.tmbundle.git
-  "HTML": git@github.com:textmate/html.tmbundle
-  "Hyperlink Helper": git@github.com:textmate/hyperlink-helper.tmbundle.git
-  "Ini": git@github.com:textmate/ini.tmbundle
-  "JSON": git@github.com:textmate/json.tmbundle
-  "Java": git@github.com:textmate/java.tmbundle
-  "JavaDoc": git@github.com:textmate/javadoc.tmbundle
-  "JavaScript jQuery": git@github.com:kswedberg/jquery-tmbundle.git
-  "JavaScript": git@github.com:textmate/javascript.tmbundle
-  "LDIF": git@github.com:skurfer/LDIF.tmbundle.git
-  "Lua": git@github.com:textmate/lua.tmbundle
-  "Mail": git@github.com:textmate/mail.tmbundle
-  "Make": git@github.com:textmate/make.tmbundle
-  "Man Pages": git@github.com:textmate/man-pages.tmbundle
-  "Markdown": git@github.com:textmate/markdown.tmbundle
-  "Math": git@github.com:textmate/math.tmbundle
-  "Mathematica": git@github.com:shadanan/mathematica-tmbundle.git
-  "Mercurial": git@github.com:textmate/mercurial.tmbundle
-  "Objective-C": git@github.com:textmate/objective-c.tmbundle
-  "PHP": git@github.com:textmate/php.tmbundle.git
-  "Perl": git@github.com:textmate/perl.tmbundle.git
-  "Postscript": git@github.com:textmate/postscript.tmbundle
-  "Property List": git@github.com:textmate/property-list.tmbundle
-  "Puppet": git@github.com:puppet-textmate-bundle/puppet-textmate-bundle.git
-  "Python": git@github.com:textmate/python.tmbundle
-  "Ruby Haml": git@github.com:textmate/ruby-haml.tmbundle
-  "Ruby Sass": git@github.com:textmate/ruby-sass.tmbundle.git
-  "Ruby Shoulda": git@github.com:textmate/ruby-shoulda.tmbundle.git
-  "Ruby Slim": git@github.com:slim-template/ruby-slim.tmbundle.git
-  "Ruby on Rails": git@github.com:textmate/ruby-on-rails-tmbundle.git
-  "Ruby": git@github.com:textmate/ruby.tmbundle
-  "Rust": git@github.com:carols10cents/rust.tmbundle.git
-  "SCM": git@github.com:textmate/scm.tmbundle
-  "SCSS": git@github.com:MarioRicalde/SCSS.tmbundle.git
-  "SQL": git@github.com:textmate/sql.tmbundle
-  "SSH Config": git@github.com:textmate/ssh-config.tmbundle
-  "Shell Script": git@github.com:textmate/shellscript.tmbundle
-  "Solarized": git@github.com:textmate/textmate-solarized.git
-  "Source": git@github.com:textmate/source.tmbundle
-  "Subversion": git@github.com:textmate/subversion.tmbundle
-  "TODO": git@github.com:textmate/todo.tmbundle
-  "Tabular": git@github.com:textmate/tabular.tmbundle
-  "Terraform": git@github.com:aurynn/Terraform.tmbundle.git
-  "Text": git@github.com:textmate/text.tmbundle
-  "TextMate": git@github.com:textmate/textmate.tmbundle
-  "Textile": git@github.com:textmate/textile.tmbundle
-  "Themes": git@github.com:textmate/themes.tmbundle.git
-  "XML": git@github.com:textmate/xml.tmbundle
-  "XQuery": git@github.com:textmate/xquery.tmbundle.git
-  "YAML": git@github.com:textmate/yaml.tmbundle
-  "iCalendar": git@github.com:textmate/icalendar.tmbundle
-  "reStructuredText": git@github.com:textmate/restructuredtext.tmbundle
+  "Apache": https://github.com/textmate/apache.tmbundle
+  "AppleScript": https://github.com/textmate/applescript.tmbundle.git
+  "Bundle Development": https://github.com/textmate/bundle-development.tmbundle
+  "Bundle Support": https://github.com/textmate/bundle-support.tmbundle
+  "C": https://github.com/textmate/c.tmbundle
+  "CSS": https://github.com/textmate/css.tmbundle
+  "CoffeeScript": https://github.com/textmate/coffee-script.tmbundle
+  "Cron": https://github.com/textmate/cron.tmbundle.git
+  "Diff": https://github.com/textmate/diff.tmbundle
+  "Docker": https://github.com/asbjornenge/Docker.tmbundle.git
+  "Dylan": https://github.com/textmate/dylan.tmbundle
+  "Gist": https://github.com/infininight/Gist.tmbundle.git
+  "Git": https://github.com/textmate/git.tmbundle
+  "Go": https://github.com/syscrusher/golang.tmbundle.git
+  "HTML": https://github.com/textmate/html.tmbundle
+  "Hyperlink Helper": https://github.com/textmate/hyperlink-helper.tmbundle.git
+  "Ini": https://github.com/textmate/ini.tmbundle
+  "JSON": https://github.com/textmate/json.tmbundle
+  "Java": https://github.com/textmate/java.tmbundle
+  "JavaDoc": https://github.com/textmate/javadoc.tmbundle
+  "JavaScript jQuery": https://github.com/kswedberg/jquery-tmbundle.git
+  "JavaScript": https://github.com/textmate/javascript.tmbundle
+  "LDIF": https://github.com/skurfer/LDIF.tmbundle.git
+  "Lua": https://github.com/textmate/lua.tmbundle
+  "Mail": https://github.com/textmate/mail.tmbundle
+  "Make": https://github.com/textmate/make.tmbundle
+  "Man Pages": https://github.com/textmate/man-pages.tmbundle
+  "Markdown": https://github.com/textmate/markdown.tmbundle
+  "Math": https://github.com/textmate/math.tmbundle
+  "Mathematica": https://github.com/shadanan/mathematica-tmbundle.git
+  "Mercurial": https://github.com/textmate/mercurial.tmbundle
+  "Objective-C": https://github.com/textmate/objective-c.tmbundle
+  "PHP": https://github.com/textmate/php.tmbundle.git
+  "Perl": https://github.com/textmate/perl.tmbundle.git
+  "Postscript": https://github.com/textmate/postscript.tmbundle
+  "Property List": https://github.com/textmate/property-list.tmbundle
+  "Puppet": https://github.com/puppet-textmate-bundle/puppet-textmate-bundle.git
+  "Python": https://github.com/textmate/python.tmbundle
+  "Ruby Haml": https://github.com/textmate/ruby-haml.tmbundle
+  "Ruby Sass": https://github.com/textmate/ruby-sass.tmbundle.git
+  "Ruby Shoulda": https://github.com/textmate/ruby-shoulda.tmbundle.git
+  "Ruby Slim": https://github.com/slim-template/ruby-slim.tmbundle.git
+  "Ruby on Rails": https://github.com/textmate/ruby-on-rails-tmbundle.git
+  "Ruby": https://github.com/textmate/ruby.tmbundle
+  "Rust": https://github.com/carols10cents/rust.tmbundle.git
+  "SCM": https://github.com/textmate/scm.tmbundle
+  "SCSS": https://github.com/MarioRicalde/SCSS.tmbundle.git
+  "SQL": https://github.com/textmate/sql.tmbundle
+  "SSH Config": https://github.com/textmate/ssh-config.tmbundle
+  "Shell Script": https://github.com/textmate/shellscript.tmbundle
+  "Solarized": https://github.com/textmate/textmate-solarized.git
+  "Source": https://github.com/textmate/source.tmbundle
+  "Subversion": https://github.com/textmate/subversion.tmbundle
+  "TODO": https://github.com/textmate/todo.tmbundle
+  "Tabular": https://github.com/textmate/tabular.tmbundle
+  "Terraform": https://github.com/aurynn/Terraform.tmbundle.git
+  "Text": https://github.com/textmate/text.tmbundle
+  "TextMate": https://github.com/textmate/textmate.tmbundle
+  "Textile": https://github.com/textmate/textile.tmbundle
+  "Themes": https://github.com/textmate/themes.tmbundle.git
+  "XML": https://github.com/textmate/xml.tmbundle
+  "XQuery": https://github.com/textmate/xquery.tmbundle.git
+  "YAML": https://github.com/textmate/yaml.tmbundle
+  "iCalendar": https://github.com/textmate/icalendar.tmbundle
+  "reStructuredText": https://github.com/textmate/restructuredtext.tmbundle
 
   


### PR DESCRIPTION
Git ssh requires a local SSH key to authenticate with github servers whereas https is more anonymous.