### PR TITLE
Install RVM (and some rubies) with Ansible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+roles/rvm_io.ruby

--- a/roles/install_ansible_bundles/defaults/main.yaml
+++ b/roles/install_ansible_bundles/defaults/main.yaml
@@ -1,0 +1,2 @@
+bundles:
+  - rvm_io.ruby

--- a/roles/install_ansible_bundles/tasks/main.yaml
+++ b/roles/install_ansible_bundles/tasks/main.yaml
@@ -1,0 +1,5 @@
+---
+  - name: Install Ansible Galaxy modules
+    local_action:
+      command ansible-galaxy install "{{ item }}" --roles-path roles
+    with: "{{ bundles }}"

--- a/roles/install_languages/tasks/main.yaml
+++ b/roles/install_languages/tasks/main.yaml
@@ -6,3 +6,12 @@
   when: ansible_os_family == "Darwin"
   with_items:
     - 'go'
+
+- name: Prepare Ruby (rvm) settings
+  set_fact:
+    rvm1_rubies: [ 'ruby-2.0.0', 'ruby-2.5.1', 'ruby-2.4.4' ]
+    rvm1_user: "{{ lookup('env', 'USER') }}"
+
+- name: Install RVM and Rubies
+  include_role:
+    name: rvm_io.ruby

--- a/setup.yaml
+++ b/setup.yaml
@@ -1,6 +1,7 @@
 ---
 - hosts: localhost
   roles:
+    - install_ansible_bundles
     - install_browsers
     - install_utilities
     - install_languages


### PR DESCRIPTION
Provide ruby versions 2.0.0, 2.4.4 and 2.5.1. This doesn't install any
gems, which will be left to the user to decide if she wants any.

rvm is provided by the `rvm_io.ruby` Ansible module, which is itself
installed here (and ignored via the newly added `.gitignore`)